### PR TITLE
Workaround/fix: let custom professions apply

### DIFF
--- a/src/statetableview.cpp
+++ b/src/statetableview.cpp
@@ -658,7 +658,12 @@ void StateTableView::super_labor_from_dwarf(){
 
 void StateTableView::apply_custom_profession() {
     QAction *a = qobject_cast<QAction*>(QObject::sender());
-    CustomProfession *cp = DT->get_custom_profession(a->text());
+
+    // Workaround: on its way the QAction's text gained a "&", remove it
+    QString s = a->text();
+    s.replace(QString("&"), QString(""));
+    CustomProfession *cp = DT->get_custom_profession(s);
+
     if (!cp)
         return;
 


### PR DESCRIPTION
The QAction's text gained a "&" somewhere, so the custom profession
isn't found via get_custom_profession(name) -> remove the "&" prior
to looking up the custom profession.

NOTE: I'm neither a C++ developer nor versed in Qt